### PR TITLE
Bugfix: use fsm_field instead of 'state'

### DIFF
--- a/fsm_admin/mixins.py
+++ b/fsm_admin/mixins.py
@@ -156,5 +156,5 @@ class FSMTransitionMixin(object):
         fsmfield = obj._meta.get_field_by_name(self.fsm_field)[0]
         transitions = fsmfield.get_all_transitions(self.model)
         for transition in transitions:
-            if transition.source in [obj.state, '*']:
+            if transition.source in [getattr(obj, self.fsm_field), '*']:
                 yield transition


### PR DESCRIPTION
When enumerating possible transitions, obj.state was always used, disregarding the fsm_field class attribute.
