### PR TITLE
Improve presentation of (uncommon) FSM fields

### DIFF
--- a/fsm_admin/mixins.py
+++ b/fsm_admin/mixins.py
@@ -140,7 +140,7 @@ class FSMTransitionMixin(object):
             object_id=obj.pk,
             object_repr=force_unicode(obj),
             action_flag=CHANGE,
-            change_message='Changed state from {0} to {1}'.format(original_state, new_state),
+            change_message='Changed {} from {} to {}'.format(self.fsm_field_instance.verbose_name, original_state, new_state),
         )
 
     def get_transition_hints(self, obj):


### PR DESCRIPTION
1.) Use get_FOO_display for choices-based FSM fields
2.) Put verbose_name of FSM field into LogEntry records
