### PR TITLE
Add default change_form template for FSMTransitionMixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,20 +25,6 @@ Or from github:
 
         admin.site.register(PublishableModel, PublishableModelAdmin)
 
-3. Override the admin change_form.html for your model
-
-        {% extends 'admin/change_form.html' %}
-        {% load fsm_admin %}
-
-        {% block submit_buttons_bottom %}{% fsm_submit_row %}{% endblock %}
-
-        {% block after_field_sets %}
-            {{ block.super }}
-            {% fsm_transition_hints %}
-        {% endblock %}  
-
-(e.g. `your_app/templates/admin/your_app/your_model/change_form.html`)
-
 ## Try the example
 
     git clone git@github.com:gadventures/django-fsm-admin.git

--- a/fsm_admin/mixins.py
+++ b/fsm_admin/mixins.py
@@ -42,6 +42,7 @@ class FSMTransitionMixin(object):
 
     # name of the FSMField on the model to transition
     fsm_field = 'state'
+    change_form_template = 'fsm_admin/change_form.html'
 
     def _fsm_get_transitions(self, obj, perms=None):
         """

--- a/fsm_admin/templates/fsm_admin/change_form.html
+++ b/fsm_admin/templates/fsm_admin/change_form.html
@@ -1,0 +1,9 @@
+{% extends 'admin/change_form.html' %}
+{% load fsm_admin %}
+
+{% block submit_buttons_bottom %}{% fsm_submit_row %}{% endblock %}
+
+{% block after_field_sets %}
+    {{ block.super }}
+    {% fsm_transition_hints %}
+{% endblock %}


### PR DESCRIPTION
Simplify the admin integration a bit, using the example template code from README directly as a default for `FSMTransitionMixin`.
