### PR TITLE
Add support for multiple fsm fields

### DIFF
--- a/fsm_admin/mixins.py
+++ b/fsm_admin/mixins.py
@@ -37,12 +37,12 @@ class FSMTransitionMixin(object):
     * In the absence of specific transition permissions, the user must
       have change permission for the model.
     """
-    # Each transition input is named with the transition.
-    # e.g. _fsmtransition-publish
-    #      _fsmtransition-delete
+    # Each transition input is named with the state field and transition.
+    # e.g. _fsmtransition-publish_state-publish
+    #      _fsmtransition-revision_state-delete
     fsm_input_prefix = '_fsmtransition'
-    # name of the FSMField on the model to transition
-    fsm_field = 'state'
+    # The name of one or more FSMFields on the model to transition
+    fsm_field = ['state',]
     change_form_template = 'fsm_admin/change_form.html'
 
     def _fsm_get_transitions(self, obj, request, perms=None):
@@ -53,8 +53,13 @@ class FSMTransitionMixin(object):
         following the pattern get_available_FIELD_transitions
         """
         user = request.user
-        transitions_func = 'get_available_user_{0}_transitions'.format(self.fsm_field)
-        transitions = getattr(obj, transitions_func)(user) if obj else []
+        fsm_fields = self._get_fsm_field_list()
+
+        transitions = {}
+        for field in fsm_fields:
+            transitions_func = 'get_available_user_{0}_transitions'.format(field)
+            transitions[field] = getattr(obj, transitions_func)(user) if obj else []
+
         return transitions
 
     def get_redirect_url(self, request, obj):
@@ -63,22 +68,22 @@ class FSMTransitionMixin(object):
         """
         return request.path
 
-    @property
-    def fsm_field_instance(self):
+    def fsm_field_instance(self, fsm_field_name):
         """
         Returns the actual state field instance, as opposed to
         fsm_field attribute representing just the field name.
         """
-        return self.model._meta.get_field_by_name(self.fsm_field)[0]
+        return self.model._meta.get_field_by_name(fsm_field_name)[0]
 
-    def display_fsm_field(self, obj):
+    def display_fsm_field(self, obj, fsm_field_name):
         """
         Makes sure get_FOO_display() is used for choices-based FSM fields.
         """
-        if self.fsm_field_instance.choices:
-            return getattr(obj, 'get_%s_display' % self.fsm_field)()
+        field_instance = self.fsm_field_instance(fsm_field_name)
+        if field_instance and field_instance.choices:
+            return getattr(obj, 'get_%s_display' % fsm_field_name)()
         else:
-            return getattr(obj, self.fsm_field)
+            return getattr(obj, fsm_field_name)
 
     def response_change(self, request, obj):
         """
@@ -106,7 +111,10 @@ class FSMTransitionMixin(object):
         """
         Checks if the requested transition is available
         """
-        return transition in (t.name for t in self._fsm_get_transitions(obj, request))
+        transitions = []
+        for field, field_transitions in self._fsm_get_transitions(obj, request).iteritems():
+            transitions += [t.name for t in field_transitions]
+        return transitions
 
     def _get_requested_transition(self, request):
         """
@@ -114,11 +122,12 @@ class FSMTransitionMixin(object):
         """
         for key in request.POST.keys():
             if key.startswith(self.fsm_input_prefix):
-                return key.split('-')[1]
+                fsm_input = key.split('-')
+                return (fsm_input[1], fsm_input[2])
         return None
 
-    def _do_transition(self, transition, request, obj, form):
-        original_state = self.display_fsm_field(obj)
+    def _do_transition(self, transition, request, obj, form, fsm_field_name):
+        original_state = self.display_fsm_field(obj, fsm_field_name)
         msg_dict = {
             'obj': force_text(obj),
             'transition': transition,
@@ -135,11 +144,11 @@ class FSMTransitionMixin(object):
             except TypeError:
                 # If the function does not have a by attribute, just call with no arguments
                 trans_func()
-            new_state = self.display_fsm_field(obj)
+            new_state = self.display_fsm_field(obj, fsm_field_name)
 
             # Mark the fsm_field as changed in the form so it will be
             # picked up when the change message is constructed
-            form.changed_data.append(self.fsm_field)
+            form.changed_data.append(fsm_field_name)
 
             msg_dict.update({'new_state': new_state, 'status': messages.SUCCESS})
         else:
@@ -149,9 +158,9 @@ class FSMTransitionMixin(object):
         setattr(obj, '_fsmtransition_results', msg_dict)
 
     def save_model(self, request, obj, form, change):
-        transition = self._get_requested_transition(request)
+        fsm_field, transition = self._get_requested_transition(request)
         if transition:
-            self._do_transition(transition, request, obj, form)
+            self._do_transition(transition, request, obj, form, fsm_field)
         super(FSMTransitionMixin, self).save_model(request, obj, form, change)
 
     def get_transition_hints(self, obj):
@@ -181,8 +190,22 @@ class FSMTransitionMixin(object):
         """
         Get valid state transitions from the current state of `obj`
         """
-        fsmfield = obj._meta.get_field_by_name(self.fsm_field)[0]
-        transitions = fsmfield.get_all_transitions(self.model)
-        for transition in transitions:
-            if transition.source in [getattr(obj, self.fsm_field), '*']:
-                yield transition
+        fsm_fields = self._get_fsm_field_list()
+        for field in fsm_fields:
+            fsmfield = obj._meta.get_field_by_name(field)[0]
+            transitions = fsmfield.get_all_transitions(self.model)
+            for transition in transitions:
+                if transition.source in [getattr(obj, field), '*']:
+                    yield transition
+
+    def _get_fsm_field_list(self):
+        """
+        Ensure backward compatibility by converting a single fsm field to
+        a list.  While we are guaranteeing compatibility we should use
+        this method to retrieve the fsm field rather than directly
+        accessing the property.
+        """
+        if not isinstance(self.fsm_field, (list, tuple,)):
+            return [self.fsm_field,]
+
+        return self.fsm_field

--- a/fsm_admin/templates/fsm_admin/fsm_submit_button.html
+++ b/fsm_admin/templates/fsm_admin/fsm_submit_button.html
@@ -1,0 +1,1 @@
+<input type="submit" value="{{ button_value }}" class="default transition-{{ transition_name }}" name="_fsmtransition-{{ fsm_field_name }}-{{ transition_name }}"/>

--- a/fsm_admin/templates/fsm_admin/fsm_submit_button_grappelli.html
+++ b/fsm_admin/templates/fsm_admin/fsm_submit_button_grappelli.html
@@ -1,0 +1,1 @@
+<li class="grp-float-left submit-button-container"><input type="submit" value="{{ button_value }}" class="default transition-{{ transition_name }}" name="_fsmtransition-{{ fsm_field_name }}-{{ transition_name }}"/></li>

--- a/fsm_admin/templates/fsm_admin/fsm_submit_button_suit.html
+++ b/fsm_admin/templates/fsm_admin/fsm_submit_button_suit.html
@@ -1,0 +1,1 @@
+<input type="submit" value="{{ button_value }}" class="btn default transition-{{ transition_name }}" name="_fsmtransition-{{ fsm_field_name }}-{{ transition_name }}"/>

--- a/fsm_admin/templates/fsm_admin/fsm_submit_line.html
+++ b/fsm_admin/templates/fsm_admin/fsm_submit_line.html
@@ -1,4 +1,4 @@
-{% load i18n admin_urls %}
+{% load i18n admin_urls fsm_admin %}
 <div class="submit-row">
 {% if show_save %}<input type="submit" value="{% trans 'Save' %}" class="default" name="_save" />{% endif %}
 {% if show_delete_link %}
@@ -10,8 +10,8 @@
 {% if show_save_and_add_another %}<input type="submit" value="{% trans 'Save and add another' %}" name="_addanother" />{% endif %}
 {% if show_save_and_continue %}<input type="submit" value="{% trans 'Save and continue editing' %}" name="_continue" />{% endif %}
  
-{% for transition_name, transition in transitions %}
-<input type="submit" value="{{ transition_name }}" class="default transition-{{ transition }}" name="_fsmtransition-{{ transition }}"/>
+{% for transition in transitions %}
+{% fsm_submit_button transition %}
 {% endfor %}
 
 </div>

--- a/fsm_admin/templates/fsm_admin/fsm_submit_line_grappelli.html
+++ b/fsm_admin/templates/fsm_admin/fsm_submit_line_grappelli.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n fsm_admin %}
 <footer class="grp-module grp-submit-row grp-fixed-footer">
     <ul class="submit-row">
         {% if show_delete_link %}<li class="grp-float-left delete-link-container"><a href="delete/" class="grp-button grp-delete-link">{% trans "Delete" %}</a></li>{% endif %}
@@ -7,13 +7,8 @@
         {% if show_save_and_add_another %}<li class="submit-button-container"><input type="submit" value="{% trans 'Save and add another' %}" name="_addanother"/></li>{% endif %}
         {% if show_save_and_continue %}<li class="submit-button-container"><input type="submit" value="{% trans 'Save and continue editing' %}" name="_continue"/></li>{% endif %}
  
-        {% comment %}
-        This is the custom bit to support FSM based transitions. Iterate over the
-        available transitions and add appropriate values that are then detected
-        in project_utils.view_mixins.FSMTransitionMixin.
-        {% endcomment %}
-        {% for transition_name, transition in transitions %}
-        <li class="grp-float-left submit-button-container"><input type="submit" value="{{ transition_name }}" class="default transition-{{ transition }}" name="_fsmtransition-{{ transition }}"/></li>
+        {% for transition in transitions %}
+            {% fsm_submit_button transition %}
         {% endfor %}
  
     </ul><br clear="all" />

--- a/fsm_admin/templates/fsm_admin/fsm_submit_line_suit.html
+++ b/fsm_admin/templates/fsm_admin/fsm_submit_line_suit.html
@@ -1,4 +1,4 @@
-﻿{% load i18n %}
+{% load i18n fsm_admin %}
 <div class="submit-row clearfix">
   {% if show_save %}<button type="submit" class="btn btn-high btn-info" name="_save" {{ onclick_attrib }}>{% trans 'Save' %}</button>{% endif %}
   {% if show_save_and_continue %}<button type="submit" name="_continue" class=" btn btn-high" {{ onclick_attrib }}>{% trans 'Save and continue editing' %}</button>{% endif %}
@@ -6,10 +6,9 @@
   {% if show_save_and_add_another %}
       <button type="submit" name="_addanother" class="btn" {{ onclick_attrib }} >{% trans 'Save and add another' %}</button>{% endif %}
   
-  
-  {% for transition_name, transition in transitions %}
-    <input type="submit" value="{{ transition_name }}" class="btn default transition-{{ transition }}" name="_fsmtransition-{{ transition }}"/>
-{% endfor %}
+    {% for transition in transitions %}
+        {% fsm_submit_button transition %}
+    {% endfor %}
 
   {% if show_delete_link %}<a href="delete/" class="text-error deletelink">{% trans "Delete" %}</a>
   {% endif %}

--- a/fsm_admin/templatetags/fsm_admin.py
+++ b/fsm_admin/templatetags/fsm_admin.py
@@ -9,11 +9,29 @@ register = template.Library()
 import logging
 logger = logging.getLogger(__name__)
 
+FSM_SUBMIT_BUTTON_TEMPLATE = 'fsm_admin/fsm_submit_button.html'
 FSM_SUBMIT_LINE_TEMPLATE = 'fsm_admin/fsm_submit_line.html'
 if 'grappelli' in settings.INSTALLED_APPS:
+    FSM_SUBMIT_BUTTON_TEMPLATE = 'fsm_admin/fsm_submit_button_grappelli.html'
     FSM_SUBMIT_LINE_TEMPLATE = 'fsm_admin/fsm_submit_line_grappelli.html'
 if 'suit' in settings.INSTALLED_APPS:
+    FSM_SUBMIT_BUTTON_TEMPLATE = 'fsm_admin/fsm_submit_button_suit.html'
     FSM_SUBMIT_LINE_TEMPLATE = 'fsm_admin/fsm_submit_line_suit.html'
+
+
+@register.inclusion_tag(FSM_SUBMIT_BUTTON_TEMPLATE)
+def fsm_submit_button(transition):
+    """
+    Render a submit button that requests an fsm state transition for a
+    single state.
+    """
+    fsm_field_name, button_value, transition_name = transition
+    return {
+        'button_value': button_value,
+        'fsm_field_name': fsm_field_name,
+        'transition_name': transition_name,
+    }
+
 
 @register.inclusion_tag(FSM_SUBMIT_LINE_TEMPLATE, takes_context=True)
 def fsm_submit_row(context):
@@ -28,6 +46,7 @@ def fsm_submit_row(context):
         if hasattr(transition, 'custom') and 'button_name' in transition.custom:
             return transition.custom['button_name']
         else:
+            # Make the function name the button title, but prettier
             return '{0} {1}'.format(transition.name.replace('_',' '), model_name).title()
 
     # The model admin defines which field we're dealing with
@@ -37,8 +56,9 @@ def fsm_submit_row(context):
     transitions = model_admin._fsm_get_transitions(original, request)
 
     ctx = submit_row(context)
-    # Make the function name the button title, but prettier
-    ctx['transitions'] = [(button_name(t), t.name) for t in transitions]
+    ctx['transitions'] = []
+    for field,field_transitions in transitions.iteritems():
+        ctx['transitions'] += [(field, button_name(t), t.name) for t in field_transitions]
     ctx['perms'] = context['perms']
 
     return ctx


### PR DESCRIPTION
Sometimes we want to be able to transition more than one fsm state
field, so add support for a list of fields to be specified.  Attempt
to retain some backward compatibility by retrieving state fields via
a method that will attempt to "fix" a single field by converting it
to a list.

Convert the inline creation of the state transition buttons to an
inclusion tag in order to hide the implementation of the transitions
in the context from the submit line template.  Include the field
name as part of the button name so we can properly negotiate our
transition.
