### PR TITLE
Add compatibility for python 3.2+

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,14 @@ Usage
 -----
 1. Add ``fsm_admin`` to your INSTALLED_APPS
 
-2. Ensure that you have "django.core.context_processors.request" in your TEMPLATE_CONTEXT_PROCESSORS in Django settings
+2. Ensure that you have "django.core.context_processors.request" in your TEMPLATE_CONTEXT_PROCESSORS in Django settings. If TEMPLATE_CONTEXT_PROCESSORS is not yet defined, add
+::
+    from django.conf import global_settings
+
+    TEMPLATE_CONTEXT_PROCESSORS = global_settings.TEMPLATE_CONTEXT_PROCESSORS + (
+        'django.core.context_processors.request',
+    )
+
 
 3. In your ``admin.py`` file, use `FSMTransitionMixin` to add behaviour to your ModelAdmin.
 

--- a/fsm_admin/mixins.py
+++ b/fsm_admin/mixins.py
@@ -112,7 +112,7 @@ class FSMTransitionMixin(object):
         Checks if the requested transition is available
         """
         transitions = []
-        for field, field_transitions in self._fsm_get_transitions(obj, request).iteritems():
+        for field, field_transitions in iter(self._fsm_get_transitions(obj, request).items()):
             transitions += [t.name for t in field_transitions]
         return transitions
 

--- a/fsm_admin/templatetags/fsm_admin.py
+++ b/fsm_admin/templatetags/fsm_admin.py
@@ -57,7 +57,7 @@ def fsm_submit_row(context):
 
     ctx = submit_row(context)
     ctx['transitions'] = []
-    for field,field_transitions in transitions.iteritems():
+    for field,field_transitions in iter(transitions.items()):
         ctx['transitions'] += [(field, button_name(t), t.name) for t in field_transitions]
     ctx['perms'] = context['perms']
 


### PR DESCRIPTION
dict.iterkeys(), dict.iteritems() and dict.itervalues() are no longer supported in python 3. The workaround was to change the functions

obj.iteritems() to iter(obj.items())

I don't know if this is compatible with python 2.x