### PR TITLE
Fixes #28

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,8 @@ Usage
 -----
 1. Add ``fsm_admin`` to your INSTALLED_APPS
 
-2. Ensure that you have "django.core.context_processors.request" in your TEMPLATE_CONTEXT_PROCESSORS in Django settings. If TEMPLATE_CONTEXT_PROCESSORS is not yet defined, add
+2. Ensure that you have "django.core.context_processors.request" in your TEMPLATE_CONTEXT_PROCESSORS
+in Django settings. If TEMPLATE_CONTEXT_PROCESSORS is not yet defined, add
 ::
     from django.conf import global_settings
 
@@ -48,6 +49,31 @@ or add additional workflow state fields with the attribute `fsm_field`
         fsm_field = ['wf_state',]
 
         admin.site.register(YourModel, YourModelAdmin)
+
+4. By adding ``custom=dict(admin=False)`` to the transition decorator, one can disallow a transition
+to show up in the admin interface. This specially is useful, if the transition method accepts
+parameters without default values, since in **django-fsm-admin** no arguments can be passed into the
+transition method.
+
+::
+        @transition(field='state', source=['startstate'], target='finalstate', custom=dict(admin=False))
+        def do_something(self, some_param):
+            # will not add a button "Do Something" to your admin model interface
+
+By adding ``FSM_ADMIN_FORCE_PERMIT = True`` to your configuration settings, the above restriction
+becomes the default. Then one must explicitly allow that a transition method shows up in the
+admin interface.
+
+::
+
+        @transition(field='state', source=['startstate'], target='finalstate', custom=dict(admin=True))
+        def proceed(self):
+            # will add a button "Proceed" to your admin model interface
+
+
+This is useful, if most of your state transitions are handled by other means, such as external
+events communicating with the API of your application.
+
 
 Try the example
 ---------------

--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,7 @@ parameters without default values, since in **django-fsm-admin** no arguments ca
 transition method.
 
 ::
+
         @transition(field='state', source=['startstate'], target='finalstate', custom=dict(admin=False))
         def do_something(self, some_param):
             # will not add a button "Do Something" to your admin model interface

--- a/fsm_admin/mixins.py
+++ b/fsm_admin/mixins.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 from collections import defaultdict
 
+from django.conf import settings
 from django.contrib import messages
 from django.utils.translation import ugettext as _
 from django.utils.encoding import force_text
@@ -44,6 +45,7 @@ class FSMTransitionMixin(object):
     # The name of one or more FSMFields on the model to transition
     fsm_field = ['state',]
     change_form_template = 'fsm_admin/change_form.html'
+    default_disallow_transition = not getattr(settings, 'FSM_ADMIN_FORCE_PERMIT', False)
 
     def _fsm_get_transitions(self, obj, request, perms=None):
         """
@@ -58,8 +60,8 @@ class FSMTransitionMixin(object):
         transitions = {}
         for field in fsm_fields:
             transitions_func = 'get_available_user_{0}_transitions'.format(field)
-            transitions[field] = getattr(obj, transitions_func)(user) if obj else []
-
+            transitions_generator = getattr(obj, transitions_func)(user) if obj else []
+            transitions[field] = self._filter_admin_transitions(transitions_generator)
         return transitions
 
     def get_redirect_url(self, request, obj):
@@ -115,6 +117,25 @@ class FSMTransitionMixin(object):
         for field, field_transitions in iter(self._fsm_get_transitions(obj, request).items()):
             transitions += [t.name for t in field_transitions]
         return transitions
+
+    def _filter_admin_transitions(self, transitions_generator):
+        """
+        Filter the given list of transitions, if their transition methods are declared as admin
+        transitions. To allow a transition inside fsm_admin, add the parameter
+        `admin=True` to the transition decorator, for example:
+        ```
+        @transition(field='state', source=['startstate'], target='finalstate', custom=dict(admin=True))
+        def do_something(self):
+            ...
+        ```
+
+        If the configuration setting `FSM_ADMIN_FORCE_PERMIT = True` then only transitions with
+        `custom=dict(admin=True)` are allowed. Otherwise, if `FSM_ADMIN_FORCE_PERMIT = False` or
+        unset only those with `custom=dict(admin=False)`
+        """
+        for transition in transitions_generator:
+            if transition.custom.get('admin', self.default_disallow_transition):
+                yield transition
 
     def _get_requested_transition(self, request):
         """


### PR DESCRIPTION
This small fix makes it possible to explicitly allows/disallow transition methods to appear in the admin interface.

For my current project, this is a MUST feature, since many transition methods accept additional parameters (thus don't work in the admin anyway) and/or shall not always appear implicitly in the admin interface.
