### PR TITLE
Use the button name as hint description

### DIFF
--- a/fsm_admin/mixins.py
+++ b/fsm_admin/mixins.py
@@ -207,7 +207,11 @@ class FSMTransitionMixin(object):
 
                 hint = getattr(condition, 'hint', '')
                 if hint:
-                    hints[transition.name].append(hint)
+                    if hasattr(transition, 'custom') and transition.custom.get(
+                            'button_name'):
+                        hints[transition.custom['button_name']].append(hint)
+                    else:
+                        hints[transition.name].append(hint)
 
         return dict(hints)
 

--- a/fsm_admin/mixins.py
+++ b/fsm_admin/mixins.py
@@ -211,7 +211,7 @@ class FSMTransitionMixin(object):
                             'button_name'):
                         hints[transition.custom['button_name']].append(hint)
                     else:
-                        hints[transition.name].append(hint)
+                        hints[transition.name.title()].append(hint)
 
         return dict(hints)
 

--- a/fsm_admin/templates/fsm_admin/fsm_transition_hints.html
+++ b/fsm_admin/templates/fsm_admin/fsm_transition_hints.html
@@ -7,7 +7,7 @@
           <div class="form-row">
             <div>
                 {% if forloop.first %}
-                  <label><strong>{{ action|title }}</strong></label>
+                  <label><strong>{{ action }}</strong></label>
                 {% endif %}
                 <p>{{ hint }}</p>
             </div>
@@ -15,4 +15,4 @@
         {% endfor %}
     {% endfor %}
   </div>
-{% endif %} 
+{% endif %}


### PR DESCRIPTION
Our transition names are english but the buttons and descriptions need to be German. This will use the (undocumented) `button_name` field for displaying hints.