### PR TITLE
Bugfixes

### DIFF
--- a/fsm_admin/mixins.py
+++ b/fsm_admin/mixins.py
@@ -116,7 +116,7 @@ class FSMTransitionMixin(object):
         transitions = []
         for field, field_transitions in iter(self._fsm_get_transitions(obj, request).items()):
             transitions += [t.name for t in field_transitions]
-        return transitions
+        return transition in transitions
 
     def _filter_admin_transitions(self, transitions_generator):
         """

--- a/fsm_admin/mixins.py
+++ b/fsm_admin/mixins.py
@@ -205,6 +205,10 @@ class FSMTransitionMixin(object):
                 if condition(obj):
                     continue
 
+                # if the transition is hidden, we don't need the hint
+                if transition.custom.get('admin', self.default_disallow_transition):
+                    continue
+
                 hint = getattr(condition, 'hint', '')
                 if hint:
                     if hasattr(transition, 'custom') and transition.custom.get(


### PR DESCRIPTION
While hacking on `fsm-admin` I found two errors - at least I'd consider them as such. Let me know if they were by design.

1.  `_is_transition_available()` wasn't actually checking if the transition passed in was available. It just returned a list of available transitions.
2. `get_transitions_hints()` was returning hints for transitions that were hidden from the admin (`custom['admin']=False`) - that wasn't helpful, at least in our case.