### PR TITLE
[RFC] fsm_transition_hints.html: use <dl>

### DIFF
--- a/fsm_admin/templates/fsm_admin/fsm_transition_hints.html
+++ b/fsm_admin/templates/fsm_admin/fsm_transition_hints.html
@@ -5,16 +5,12 @@
     <h2>{% trans "Hints in order to..." %}</h2>
 
     {% for action, hints in transition_hints.items %}
-        {% for hint in hints %}
-          <div class="form-row">
-            <div>
-                {% if forloop.first %}
-                  <label><strong>{{ action }}</strong></label>
-                {% endif %}
-                <p>{{ hint }}</p>
-            </div>
-          </div>
-        {% endfor %}
+        <dl>
+            <dt>{{ action }}</dt>
+            {% for hint in hints %}
+                <dd>{{ hint }}</dd>
+            {% endfor %}
+        </dl>
     {% endfor %}
   </div>
 {% endif %}


### PR DESCRIPTION
I found this better suited with Django 1.11 and a list of two hints for one transition.

Before:
![2017-09-19-174127_341x156_scrot](https://user-images.githubusercontent.com/9766/30601264-cf1be90c-9d61-11e7-9962-187a8ed6f754.png)

After:
![2017-09-19-174019_367x240_scrot](https://user-images.githubusercontent.com/9766/30601263-cf17f860-9d61-11e7-8f50-6e2be7c64951.png)

Might be related to html/style changes in Django itself, and needs adjustments in other templates maybe, too?!