### PR TITLE
allow css customization in submitline buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist
 *.egg-info
 docs/_build
 *.pyc
+*.idea
 .DS_Store
 db.sqlite3
 *.tmp

--- a/fsm_admin/templates/fsm_admin/fsm_submit_button.html
+++ b/fsm_admin/templates/fsm_admin/fsm_submit_button.html
@@ -1,1 +1,1 @@
-<input type="submit" value="{{ button_value }}" class="default transition-{{ transition_name }}" name="_fsmtransition-{{ fsm_field_name }}-{{ transition_name }}"/>
+<input type="submit" value="{{ button_value }}" class="default transition-{{ transition_name }}{% if transition_css_classes %} {{ transition_css_classes }}{% endif %}" name="_fsmtransition-{{ fsm_field_name }}-{{ transition_name }}"/>

--- a/fsm_admin/templates/fsm_admin/fsm_submit_button_grappelli.html
+++ b/fsm_admin/templates/fsm_admin/fsm_submit_button_grappelli.html
@@ -1,1 +1,1 @@
-<li class="grp-float-left submit-button-container"><input type="submit" value="{{ button_value }}" class="default transition-{{ transition_name }}" name="_fsmtransition-{{ fsm_field_name }}-{{ transition_name }}"/></li>
+<li class="grp-float-left submit-button-container"><input type="submit" value="{{ button_value }}" class="default transition-{{ transition_name }}{% if transition_css_classes %} {{ transition_css_classes }}{% endif %}" name="_fsmtransition-{{ fsm_field_name }}-{{ transition_name }}"/></li>

--- a/fsm_admin/templates/fsm_admin/fsm_submit_button_suit.html
+++ b/fsm_admin/templates/fsm_admin/fsm_submit_button_suit.html
@@ -1,1 +1,1 @@
-<button type="submit" class="btn default transition-{{ transition_name }}" name="_fsmtransition-{{ fsm_field_name }}-{{ transition_name }}">{{ button_value }}</button>
+<button type="submit" class="btn default transition-{{ transition_name }}{% if transition_css_classes %} {{ transition_css_classes }}{% endif %}" name="_fsmtransition-{{ fsm_field_name }}-{{ transition_name }}">{{ button_value }}</button>

--- a/fsm_admin/templates/fsm_admin/fsm_submit_button_wpadmin.html
+++ b/fsm_admin/templates/fsm_admin/fsm_submit_button_wpadmin.html
@@ -1,1 +1,1 @@
-<input type="submit" value="{{ button_value }}" class="default transition-{{ transition_name }}" name="_fsmtransition-{{ fsm_field_name }}-{{ transition_name }}"/>
+<input type="submit" value="{{ button_value }}" class="default transition-{{ transition_name }}{% if transition_css_classes %} {{ transition_css_classes }}{% endif %}" name="_fsmtransition-{{ fsm_field_name }}-{{ transition_name }}"/>

--- a/fsm_admin/templatetags/fsm_admin.py
+++ b/fsm_admin/templatetags/fsm_admin.py
@@ -31,11 +31,12 @@ def fsm_submit_button(transition):
     Render a submit button that requests an fsm state transition for a
     single state.
     """
-    fsm_field_name, button_value, transition_name = transition
+    fsm_field_name, button_value, transition_name, transition_css_classes = transition
     return {
         'button_value': button_value,
         'fsm_field_name': fsm_field_name,
         'transition_name': transition_name,
+        'transition_css_classes': transition_css_classes,
     }
 
 
@@ -62,6 +63,12 @@ def fsm_submit_row(context):
             # Make the function name the button title, but prettier
             return '{0} {1}'.format(transition.name.replace('_', ' '), model_name).title()
 
+    def button_css_classes(transition):
+        if hasattr(transition, 'custom') and 'css_classes' in transition.custom:
+            return transition.custom['css_classes']
+        else:
+            return ""
+
     # The model admin defines which field we're dealing with
     # and has some utils for getting the transitions.
     request = context['request']
@@ -72,7 +79,7 @@ def fsm_submit_row(context):
     ctx['transitions'] = []
     for field, field_transitions in iter(transitions.items()):
         ctx['transitions'] += sorted(
-            [(field, button_name(t), t.name) for t in field_transitions],
+            [(field, button_name(t), t.name, button_css_classes(t)) for t in field_transitions],
             key=lambda e: e[1], reverse=True
         )
     ctx['perms'] = context['perms']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Django>=1.6
-django-fsm==2.0.1
+django-fsm>=2.0.1


### PR DESCRIPTION
Resolves https://github.com/gadventures/django-fsm-admin/issues/87

This update allows submit line customizations like this:![Screenshot 2021-02-01 at 16 46 33](https://user-images.githubusercontent.com/2088831/106482657-f5269b80-64ad-11eb-86c6-62f04efd0f9a.png)
Obviously that green button is customizable modifying the change_form template, too

I didn't update the example app because it was off-topic to fix it