### PR TITLE
add a way to display transitions of related models into admin

### DIFF
--- a/fsm_admin/templates/fsm_admin/fsm_submit_button.html
+++ b/fsm_admin/templates/fsm_admin/fsm_submit_button.html
@@ -1,1 +1,1 @@
-<input type="submit" value="{{ button_value }}" class="default transition-{{ transition_name }}" name="_fsmtransition-{{ fsm_field_name }}-{{ transition_name }}"/>
+<input type="submit" value="{{ button_value }}" class="default transition-{{ transition_name }}" name="_fsmtransition-{{ fsm_field_name }}-{{ transition_name }}-{{ foreign_key }}"/>


### PR DESCRIPTION
### Objectives
This change add a way to display transitions that are defined in related models (foreign keys, one to one fields) into models admins.

### Example
class Wheel(BaseModel):
    orientation = FSMField(default="CENTER", choices=["LEFT", "CENTER", "RIGHT"], protected=True)

    @transition(
        field=orientation,
        source=["CENTER"],
        target="LEFT",
        custom=dict(admin=True),
    )
    def turn_left(self):
        pass

class Car(BaseModel):
    status = FSMField(default="STOP", choices=["STOP", "START"], protected=True)

    wheel = models.OneToOneField(
        Wheel,
        related_name="car",
        on_delete=models.CASCADE,
        null=True,
        blank=True,
    )

    @transition(
        field=status,
        source=["STOP"],
        target="START",
        custom=dict(admin=True),
    )
    def start(self):
        pass

@admin.register(Car)
class CarAdmin(FSMTransitionMixin, admin.ModelAdmin):
    readonly_fields = ["status"]
    fsm_field = ["status"]
    list_display = ["status",]
    fields = readonly_fields

    # because we add this parameter it will displays "turn_left" transition into CarAdmin change form
    # in addition to car start transition
    foreign_keys = ["wheel"] 