### PR TITLE
Made updates to the deprecated ugettext function in django.utils.translation and also to the force_text function in django.utils.encoding

### DIFF
--- a/fsm_admin/mixins.py
+++ b/fsm_admin/mixins.py
@@ -4,8 +4,10 @@ from collections import defaultdict
 
 from django.conf import settings
 from django.contrib import messages
-from django.utils.translation import ugettext as _
-from django.utils.encoding import force_text
+# from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
+# from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.contrib.admin.templatetags.admin_urls import add_preserved_filters
 from django.http import HttpResponseRedirect
 


### PR DESCRIPTION
updated the django.utils.translation to make up for the deprecated ugettext function, replaced with gettext and also the django.utils.encoding force_text replaced with force_str