### PR TITLE
Update/fix submit_line template

### DIFF
--- a/fsm_admin/templates/fsm_admin/fsm_submit_line.html
+++ b/fsm_admin/templates/fsm_admin/fsm_submit_line.html
@@ -1,17 +1,12 @@
+{% extends 'admin/submit_line.html' %}
 {% load i18n admin_urls fsm_admin %}
+
 <div class="submit-row">
-{% if show_save %}<input type="submit" value="{% trans 'Save' %}" class="default" name="_save" />{% endif %}
-{% if show_delete_link %}
-    {% url opts|admin_urlname:'delete' original.pk|admin_urlquote as delete_url %}
-    <p class="deletelink-box"><a href="{% add_preserved_filters delete_url %}" class="deletelink">{% trans "Delete" %}</a></p>
-{% endif %}
+{% block submit-row %}
+    {{ block.super }}
 
-{% if show_save_as_new %}<input type="submit" value="{% trans 'Save as new' %}" name="_saveasnew" />{%endif%}
-{% if show_save_and_add_another %}<input type="submit" value="{% trans 'Save and add another' %}" name="_addanother" />{% endif %}
-{% if show_save_and_continue %}<input type="submit" value="{% trans 'Save and continue editing' %}" name="_continue" />{% endif %}
- 
-{% for transition in transitions %}
-{% fsm_submit_button transition %}
-{% endfor %}
-
+    {% for transition in transitions %}
+        {% fsm_submit_button transition %}
+    {% endfor %}
+{% endblock %}
 </div>


### PR DESCRIPTION
Currently it would not include the "Close" link, that was added in
Django 2.1
(https://github.com/django/django/commit/825f0beda804e48e9197fcf3b0d909f9f548aa47).

This only updates the default template, where `{{ block.super }}` can be
used to get updates automatically.