### PR TITLE
Fix ugettext and force_text import errors in Django 4.x

### DIFF
--- a/fsm_admin/mixins.py
+++ b/fsm_admin/mixins.py
@@ -4,7 +4,10 @@ from collections import defaultdict
 
 from django.conf import settings
 from django.contrib import messages
-from django.utils.translation import ugettext as _
+try:
+    from django.utils.translation import ugettext as _
+except ImportError:
+    from django.utils.translation import gettext as _
 from django.utils.encoding import force_text
 from django.contrib.admin.templatetags.admin_urls import add_preserved_filters
 from django.http import HttpResponseRedirect

--- a/fsm_admin/mixins.py
+++ b/fsm_admin/mixins.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from ast import Import
 
 from collections import defaultdict
 
@@ -8,7 +9,10 @@ try:
     from django.utils.translation import ugettext as _
 except ImportError:
     from django.utils.translation import gettext as _
-from django.utils.encoding import force_text
+try:
+    from django.utils.encoding import force_text
+except ImportError:
+    from django.utils.encoding import force_str as force_text
 from django.contrib.admin.templatetags.admin_urls import add_preserved_filters
 from django.http import HttpResponseRedirect
 


### PR DESCRIPTION
Django ugettext and force_text are now deprecated and now removed in version 4.x. This change adds compatibility support for version 4.x without breaking 3.x